### PR TITLE
Fix .codeclimate.yml

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -32,8 +32,8 @@ plugins:
 exclude_patterns:
 - "app/assets/javascripts/handlebars.js"
 - "client/src/semantic-ui/"
-- "config/
-- "coverage/
+- "config/"
+- "coverage/"
 - "db/"
 - "dist/"
 - "features/"

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -17,8 +17,7 @@ plugins:
     enabled: true
     config:
       languages:
-      javascript:
-      ruby:
+       ruby:
         mass_threshold: 30
   eslint:
     enabled: true


### PR DESCRIPTION
Hey there, Dave here with Code Climate. This PR will get you analysis up and running. A couple things were causing it to fail:

- Unclosed quotes on Lines 35 and 36
- A threshold wasn't specified for JavaScript
- Indentation was missing under `languages` node